### PR TITLE
make referral name from url case always lowercase

### DIFF
--- a/referral/middleware.py
+++ b/referral/middleware.py
@@ -6,7 +6,7 @@ class ReferrerMiddleware():
     def process_request(self, request):
         if settings.GET_PARAMETER in request.GET:
             referrer = None
-            referrer_name = request.GET[settings.GET_PARAMETER]
+            referrer_name = request.GET.get(settings.GET_PARAMETER, '').lower()
             try:
                 referrer = Referrer.objects.get(name=referrer_name)
             except Referrer.DoesNotExist:


### PR DESCRIPTION
We shouldn't assume anything about the case of a url. This makes all referral names lowercase.
