### PR TITLE
Fix referrer name handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,19 @@ The name of the session key that will hold the detected referrer
 
 ###REFERRAL_AUTO_CREATE
 
-Defines weather unknown referrers shall be autocreated
+Defines whether unknown referrers shall be autocreated
 
 	Default: True
 
 ###REFERRAL_AUTO_ASSOCIATE
-Defines weather referrest should be associated to campaigns automatically using patterns
+Defines whether referrers should be associated to campaigns automatically using patterns
 
 	Default: True
+
+###REFERRAL_CASE_SENSITIVE
+Defines whether or referrer names are case-sensitive or not.
+
+  Default: False
 
 ## Testing
 

--- a/referral/middleware.py
+++ b/referral/middleware.py
@@ -6,9 +6,14 @@ class ReferrerMiddleware():
     def process_request(self, request):
         if settings.GET_PARAMETER in request.GET:
             referrer = None
-            referrer_name = request.GET.get(settings.GET_PARAMETER, '').lower()
+            referrer_name = request.GET.get(settings.GET_PARAMETER, '').strip()
+            if not referrer_name:
+                return
             try:
-                referrer = Referrer.objects.get(name=referrer_name)
+                if settings.CASE_SENSITIVE:
+                    referrer = Referrer.objects.get(name=referrer_name)
+                else:
+                    referrer = Referrer.objects.get(name__iexact=referrer_name)
             except Referrer.DoesNotExist:
                 if settings.AUTO_CREATE:
                     referrer = Referrer(name=referrer_name)

--- a/referral/settings.py
+++ b/referral/settings.py
@@ -11,3 +11,6 @@ AUTO_CREATE = getattr(settings, 'REFERRAL_AUTO_CREATE', True)
 
 # If this is set auto created referrers will be associated to a campaign that defines a matching pattern. Default: True
 AUTO_ASSOCIATE = getattr(settings, 'REFERRAL_AUTO_ASSOCIATE', True)
+
+# If this is set to True, referral names will be case-sensitive.
+CASE_SENSITIVE = getattr(settings, 'REFERRAL_CASE_SENSITIVE', False)

--- a/referral/tests/test_middlewares.py
+++ b/referral/tests/test_middlewares.py
@@ -20,3 +20,33 @@ class ReferrerMiddlewareTest(TestCase):
         self.request.GET[settings.GET_PARAMETER] = "new_ref"
         self.ref_middleware.process_request(self.request)
         self.assertEqual(Referrer.objects.all()[0].name, "new_ref")
+
+    def test_process_request_new_ref_no_autocreate(self):
+        settings.AUTO_CREATE = False
+        self.request.GET[settings.GET_PARAMETER] = "new_ref"
+        self.ref_middleware.process_request(self.request)
+        self.assertEqual(Referrer.objects.count(), 0)
+        settings.AUTO_CREATE = True
+
+    def test_referral_case_sensitive(self):
+        settings.CASE_SENSITIVE = True
+        self.request.GET[settings.GET_PARAMETER] = "new_ref"
+        self.ref_middleware.process_request(self.request)
+        self.assertEqual(Referrer.objects.count(), 1)
+
+        self.request.GET[settings.GET_PARAMETER] = "NEW_REF"
+        self.ref_middleware.process_request(self.request)
+        self.assertEqual(Referrer.objects.count(), 2)
+
+        self.assertEqual(Referrer.objects.filter(name='new_ref').count(), 1)
+        self.assertEqual(Referrer.objects.filter(name='NEW_REF').count(), 1)
+        settings.CASE_SENSITIVE = False
+
+    def test_referral_case_insensitive(self):
+        self.request.GET[settings.GET_PARAMETER] = "new_ref"
+        self.ref_middleware.process_request(self.request)
+        self.assertEqual(Referrer.objects.count(), 1)
+
+        self.request.GET[settings.GET_PARAMETER] = "NEW_REF"
+        self.ref_middleware.process_request(self.request)
+        self.assertEqual(Referrer.objects.count(), 1)


### PR DESCRIPTION
* Strip leading and trailing whitespace from referrer name. Ignore
  blank referrer names after stripping whitespace.

* Do not downcase referrer name before using it in the ORM query.

* Use iexact in ORM query instead.

* Add REFERRAL_CASE_SENSITIVE option. Defaults to False. Set to True if
  you want case-sensitive referral name lookups.