### PR TITLE
Support Django1.8 (No code changes only docs + tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
+sudo: False
 install:
   - "pip install tox"
 script:
   - "tox"
 env:
+  - "TOXENV=py34-1.8.X"
+  - "TOXENV=py27-1.8.X"
   - "TOXENV=py34-1.7.X"
   - "TOXENV=py27-1.7.X"
   - "TOXENV=py34-1.6.X"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ lead him to your website.
 * django 1.7 migrations + legacy south support
 * No dependencies
 * 100% Test coverage
-* Supports django 1.4 - 1.7
+* Supports django 1.4 - 1.8
 * supports python 2 + 3
 
 ## Download

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@
 
 [tox]
 envlist =
+    py34-1.8.X,
+    py27-1.8.X,
     py34-1.7.X,
     py27-1.7.X,
     py34-1.6.X,
@@ -20,6 +22,18 @@ setenv =
 commands =
     django-admin.py --version
     django-admin.py test referral
+
+[testenv:py34-1.8.X]
+basepython = python3.4
+deps =
+    django>=1.7, <1.8
+    factory_boy==2.4.1
+
+[testenv:py27-1.8.X]
+basepython = python2.7
+deps =
+    django>=1.7, <1.8
+    factory_boy==2.4.1
 
 [testenv:py34-1.7.X]
 basepython = python3.4


### PR DESCRIPTION
* Start testing django1.8
* Update README to show django 1.8 tests are passing
* Update travis-ci to use new container based testing infrastructure. 